### PR TITLE
Work for 1.3.0 Update

### DIFF
--- a/ChildToNPC/Patches/FarmHouseGetChildrenPatch.cs
+++ b/ChildToNPC/Patches/FarmHouseGetChildrenPatch.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using StardewValley.Characters;
+
+namespace ChildToNPC.Patches
+{
+    /* Prefix for getChildren
+     * The game uses the FarmHouse to check the children that the player has,
+     * so when ChildToNPC removes them from the FarmHouse, the game loses track of them.
+     * This method is patched so that the game has access to children who aren't in the farmhouse.
+     */
+    class FarmHouseGetChildrenPatch
+    {
+        public static void Postfix(ref List<Child> __result)
+        {
+            List<Child> resultList = __result;
+            List<Child> allChildList = ModEntry.allChildren;
+
+            // Check if allChildren has been initialized yet
+            if (allChildList != null && allChildList.Count > 0)
+            {
+                resultList = allChildList;
+
+                // Verify that allChildren contains all children
+                foreach (Child child in resultList)
+                {
+                    if (!allChildList.Contains(child))
+                    {
+                        if (ModEntry.monitor != null)
+                            ModEntry.monitor.Log("The allChildren list is missing a child: " + child.Name, StardewModdingAPI.LogLevel.Debug);
+                        resultList.Add(child);
+                    }
+                }
+            }
+
+            __result = resultList;
+        }
+    }
+}

--- a/ChildToNPC/Patches/NPCArriveAtFarmHousePatch.cs
+++ b/ChildToNPC/Patches/NPCArriveAtFarmHousePatch.cs
@@ -16,6 +16,10 @@ namespace ChildToNPC.Patches
             if (!ModEntry.IsChildNPC(__instance))
                 return;
 
+            /* Code from NPC.arriveAtFarmHouse */
+            if (Game1.newDay || Game1.timeOfDay <= 630)
+                return;
+
             __instance.setTilePosition(farmHouse.getEntryLocation());
             __instance.ignoreScheduleToday = true;
             __instance.temporaryController = null;
@@ -29,13 +33,23 @@ namespace ChildToNPC.Patches
             }
             else
             {
-                __instance.controller = new PathFindController(__instance, farmHouse, farmHouse.getRandomOpenPointInHouse(Game1.random, 0, 30), 2);
+                Point randomPoint = farmHouse.getRandomOpenPointInHouse(Game1.random, 0, 30);
+                Point bedPoint = new Point((int)__instance.DefaultPosition.X / 64, (int)__instance.DefaultPosition.Y / 64);
+                if (!randomPoint.Equals(Point.Zero))
+                    __instance.controller = new PathFindController(__instance, farmHouse, randomPoint, 2);
+                else
+                    __instance.controller = new PathFindController(__instance, farmHouse, bedPoint, 2);
             }
 
             if(__instance.controller.pathToEndPoint == null)
             {
                 __instance.willDestroyObjectsUnderfoot = true;
-                __instance.controller = new PathFindController(__instance, farmHouse, farmHouse.getRandomOpenPointInHouse(Game1.random, 0, 30), 0);
+                Point randomPoint = farmHouse.getRandomOpenPointInHouse(Game1.random, 0, 30);
+                Point bedPoint = new Point((int)__instance.DefaultPosition.X / 64, (int)__instance.DefaultPosition.Y / 64);
+                if (!randomPoint.Equals(Point.Zero))
+                    __instance.controller = new PathFindController(__instance, farmHouse, randomPoint, 0);
+                else
+                    __instance.controller = new PathFindController(__instance, farmHouse, bedPoint, 2);
                 //__instance.setNewDialogue(Game1.LoadStringByGender(__instance.Gender, "Strings\\StringsFromCSFiles:NPC.cs.4500"), false, false);
             }
 

--- a/ChildToNPC/Patches/NPCPerformTenMinuteUpdatePatch.cs
+++ b/ChildToNPC/Patches/NPCPerformTenMinuteUpdatePatch.cs
@@ -19,37 +19,34 @@ namespace ChildToNPC.Patches
                 return true;
             
             FarmHouse farmHouse = Utility.getHomeOfFarmer(Game1.player);
-            if (farmHouse.characters.Contains(__instance))
+            if (!farmHouse.characters.Contains(__instance))
+                return true;
+
+            ModConfig config = ModEntry.Config;
+            //Send children to bed when inside home
+            if (config.DoChildrenHaveCurfew && Game1.timeOfDay == config.CurfewTime)
             {
-                ModConfig config = ModEntry.Config;
-                //Send children to bed when inside home
-                if (config.DoChildrenHaveCurfew && Game1.timeOfDay == config.CurfewTime)
-                {
-                    __instance.IsWalkingInSquare = false;
-                    __instance.Halt();
-                    __instance.temporaryController = null;
+                __instance.IsWalkingInSquare = false;
+                __instance.Halt();
+                __instance.temporaryController = null;
 
-                    //Child is at home, directly path to bed (DefaultPosition)
-                    Point bedPoint = new Point((int)__instance.DefaultPosition.X / 64, (int)__instance.DefaultPosition.Y / 64);
-                    __instance.controller = new PathFindController(__instance, farmHouse, bedPoint, 2);
+                //Child is at home, directly path to bed (DefaultPosition)
+                Point bedPoint = farmHouse.getChildBed(__instance.Gender);
+                __instance.controller = new PathFindController(__instance, farmHouse, bedPoint, 2);
 
-                    if (__instance.controller.pathToEndPoint == null || !farmHouse.isTileOnMap(__instance.controller.pathToEndPoint.Last().X, __instance.controller.pathToEndPoint.Last().Y))
-                        __instance.controller = null;
-                }
-                //Make children wander if they have nothing better to do
-                else if (__instance.controller == null && config.DoChildrenWander && Game1.timeOfDay % 100 == 0 && Game1.timeOfDay < config.CurfewTime)
-                {
-                    if (!__instance.currentLocation.Equals(Utility.getHomeOfFarmer(Game1.player)))
-                        return true;
+                if (__instance.controller.pathToEndPoint == null || !farmHouse.isTileOnMap(__instance.controller.pathToEndPoint.Last().X, __instance.controller.pathToEndPoint.Last().Y))
+                    __instance.controller = null;
+            }
+            //Make children wander if they have nothing better to do
+            else if (__instance.controller == null && config.DoChildrenWander && Game1.timeOfDay % 100 == 0 && Game1.timeOfDay < config.CurfewTime)
+            {
+                __instance.IsWalkingInSquare = false;
+                __instance.Halt();
 
-                    __instance.IsWalkingInSquare = false;
-                    __instance.Halt();
-
-                    //If I'm going to prevent them from wandering into doorways, I need to do it here.
-                    __instance.controller = new PathFindController(__instance, farmHouse, farmHouse.getRandomOpenPointInHouse(Game1.random, 0, 30), 2);
-                    if (__instance.controller.pathToEndPoint == null || !farmHouse.isTileOnMap(__instance.controller.pathToEndPoint.Last().X, __instance.controller.pathToEndPoint.Last().Y))
-                        __instance.controller = null;
-                }
+                //If I'm going to prevent them from wandering into doorways, I need to do it here.
+                __instance.controller = new PathFindController(__instance, farmHouse, farmHouse.getRandomOpenPointInHouse(Game1.random, 0, 30), 2);
+                if (__instance.controller.pathToEndPoint == null || !farmHouse.isTileOnMap(__instance.controller.pathToEndPoint.Last().X, __instance.controller.pathToEndPoint.Last().Y))
+                    __instance.controller = null;
             }
 
             return true;

--- a/ChildToNPC/Patches/NPCPrepareToDisembarkOnNewSchedulePathPatch.cs
+++ b/ChildToNPC/Patches/NPCPrepareToDisembarkOnNewSchedulePathPatch.cs
@@ -19,7 +19,9 @@ namespace ChildToNPC.Patches
             if (!ModEntry.IsChildNPC(__instance))
                 return;
             
-            if(Utility.getGameLocationOfCharacter(__instance) is FarmHouse)
+            /* Code from NPC.prepareToDisembarkOnNewSchedulePath */
+
+            if(__instance.temporaryController == null && Utility.getGameLocationOfCharacter(__instance) is FarmHouse)
             {
                 __instance.temporaryController = new PathFindController(__instance, __instance.getHome(), new Point(__instance.getHome().warps[0].X, __instance.getHome().warps[0].Y), 2, true)
                 {

--- a/ChildToNPC/Patches/PFCHandleWarpsPatch.cs
+++ b/ChildToNPC/Patches/PFCHandleWarpsPatch.cs
@@ -17,6 +17,8 @@ namespace ChildToNPC.Patches
             if (!ModEntry.IsChildNPC(___character))
                 return true;
 
+            /* Code from PathFindController.handleWarps */
+
             Warp warp = __instance.location.isCollidingWithWarpOrDoor(position);
             if (warp == null)
                 return false;


### PR DESCRIPTION
Adds a new file, FarmHouseGetChildrenPatch, which patches the FarmHouse.getChildren method. This allows the method to access Child instances which have been removed from the FarmHouse and replaced by an NPC.
Additional minor edits to other files, mostly in style.